### PR TITLE
changed the 0.start_javase.sh to be able to support the redirect

### DIFF
--- a/image/scripts/start.d/0.start_javase.sh
+++ b/image/scripts/start.d/0.start_javase.sh
@@ -37,6 +37,12 @@ JAVA_HEAP=$(/opt/produban/bin/java-buildpack-memory-calculator -memoryWeights=he
 
 if [ -n "$ARTIFACT_URL" ]
 then
+  echo "INFO: Testing $ARTIFACT_URL for Redirect "
+  location=$(curl -I "$ARTIFACT_URL" | grep ^Location) 
+  if [ ! -z "$location" ]; then
+    ARTIFACT_URL=$(echo $location | sed -e 's/Location://' | tr -d '[:space:]')
+    echo "INFO: Redirected to $ARTIFACT_URL "
+  fi;
   file=`basename "$ARTIFACT_URL"`
   wget -q --no-check-certificate --connect-timeout=5 --read-timeout=10 --tries=2 -O "/tmp/$file" "$ARTIFACT_URL"
 


### PR DESCRIPTION
Changed the 0.start_javase.sh to be able to support the redirect function of nexus. That is, having an ARTIFACT_URL which has a redirect in it (using the Location header) , instead of the actual download file.
    
Joe
